### PR TITLE
fixes pre-release and build parsing

### DIFF
--- a/Command/VersionBumpCommand.php
+++ b/Command/VersionBumpCommand.php
@@ -30,8 +30,8 @@ class VersionBumpCommand extends ContainerAwareCommand
             ->addOption('major', null, InputOption::VALUE_OPTIONAL, 'Bump MAJOR version by given number', 0)
             ->addOption('minor', null, InputOption::VALUE_OPTIONAL, 'Bump MINOR version by given number', 0)
             ->addOption('patch', null, InputOption::VALUE_OPTIONAL, 'Bump PATCH version by given number', 0)
-            ->addOption('prerelease', null, InputOption::VALUE_IS_ARRAY | InputOption::VALUE_OPTIONAL, 'Add PRERELEASE to version', null)
-            ->addOption('build', null, InputOption::VALUE_IS_ARRAY | InputOption::VALUE_OPTIONAL, 'Add BUILD to version', null);
+            ->addOption('prerelease', null, InputOption::VALUE_OPTIONAL, 'Add PRERELEASE to version', array())
+            ->addOption('build', null, InputOption::VALUE_OPTIONAL, 'Add BUILD to version', array());
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -72,23 +72,17 @@ class VersionBumpCommand extends ContainerAwareCommand
                 $builder->incrementPatch(intval($input->getOption('patch')));
             }
 
-            if ($input->getOption('prerelease')) {
-                $preRelease = $input->getOption('prerelease');
-                if (in_array(null, $preRelease)) {
-                    $preRelease = array();
-                }
-
-                $builder->setPreRelease($preRelease);
+            $preRelease = $input->getOption('prerelease');
+            if (!is_array($preRelease)) {
+                $preRelease = explode('.', $preRelease);
             }
+            $builder->setPreRelease($preRelease);
 
-            if ($input->getOption('build')) {
-                $build = $input->getOption('build');
-                if (in_array(null, $build)) {
-                    $build = array();
-                }
-
-                $builder->setBuild($build);
+            $build = $input->getOption('build');
+            if (!is_array($build)) {
+                $build = explode('.', $build);
             }
+            $builder->setBuild($build);
 
             $version = $builder->getVersion();
 

--- a/Handler/ParameterHandler.php
+++ b/Handler/ParameterHandler.php
@@ -19,10 +19,16 @@ class ParameterHandler implements HandlerInterface
      */
     private $versionParameter;
 
-    public function __construct($path, $versionParameter)
+    /**
+     * @var string
+     */
+    protected $versionFile;
+
+    public function __construct($path, $versionParameter, $versionFile)
     {
         $this->path = $path;
         $this->versionParameter = $versionParameter;
+        $this->versionFile = $versionFile;
     }
 
     /**
@@ -56,7 +62,7 @@ class ParameterHandler implements HandlerInterface
      */
     private function readParametersFile()
     {
-        $parametersFile = $this->path . '/config/parameters.yml';
+        $parametersFile = $this->path . '/config//'.$this->versionFile;
         if (!is_file($parametersFile)) {
             return array('parameters');
         }

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -31,5 +31,11 @@
 
         <service id="shivas_versioning.manager" class="%shivas_versioning.manager.class%" />
 
+        <service id="shivas_versioning.twig_extension"
+                 class="%shivas_versioning.twig.class%"
+                 public="false">
+            <argument type="service" id="shivas_versioning.manager"/>
+            <tag name="twig.extension" />
+        </service>
     </services>
 </container>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -9,6 +9,7 @@
         <parameter key="shivas_versioning.handlers.git.class">Shivas\VersioningBundle\Handler\GitRepositoryHandler</parameter>
         <parameter key="shivas_versioning.handlers.init.class">Shivas\VersioningBundle\Handler\InitialVersionHandler</parameter>
         <parameter key="shivas_versioning.handlers.parameter.class">Shivas\VersioningBundle\Handler\ParameterHandler</parameter>
+        <parameter key="shivas_versioning.twig.class">Shivas\VersioningBundle\Twig\VersionExtension</parameter>
     </parameters>
 
     <services>
@@ -20,6 +21,7 @@
         <service id="shivas_versioning.handlers.parameters" class="%shivas_versioning.handlers.parameter.class%">
             <argument>%kernel.root_dir%</argument>
             <argument>%shivas_versioning.version_parameter%</argument>
+            <argument>%shivas_versioning.version_file%</argument>
             <tag name="shivas_versioning.handler" alias="parameter" priority="-50" />
         </service>
 
@@ -28,5 +30,6 @@
         </service>
 
         <service id="shivas_versioning.manager" class="%shivas_versioning.manager.class%" />
+
     </services>
 </container>

--- a/Twig/VersionExtension.php
+++ b/Twig/VersionExtension.php
@@ -1,0 +1,179 @@
+<?php
+
+namespace Shivas\VersioningBundle\Twig;
+
+use Herrera\Version\Dumper;
+use Herrera\Version\Parser;
+use Herrera\Version\Builder;
+use Shivas\VersioningBundle\Service\VersionsManager;
+
+
+class VersionExtension extends \Twig_Extension implements \Twig_Extension_GlobalsInterface
+{
+
+    /**
+     * @var Builder
+     */
+    protected $builder;
+
+    /**
+     * @var VersionsManager
+     */
+    protected $versioningManager;
+
+    /**
+     * VersionExtension constructor.
+     *
+     * @param $versioningManager VersionsManager
+     */
+    public function __construct(VersionsManager $versioningManager)
+    {
+        $this->versioningManager = $versioningManager;
+        $version = $versioningManager->getVersion();
+        $this->builder = Parser::toBuilder(Dumper::toString($version));
+    }
+
+    public function getFunctions()
+    {
+        return array(
+            new \Twig_SimpleFunction('semver_version', array($this, 'getVersion')),
+            new \Twig_SimpleFunction('semver_version_gitlab', array($this, 'getVersionGitlab')),
+            new \Twig_SimpleFunction('semver_major', array($this, 'getMajorVersion')),
+            new \Twig_SimpleFunction('semver_minor', array($this, 'getMinorVersion')),
+            new \Twig_SimpleFunction('semver_patch', array($this, 'getPatchVersion')),
+            new \Twig_SimpleFunction('semver_pre_release', array($this, 'getPreReleaseVersion')),
+            new \Twig_SimpleFunction('semver_build', array($this, 'getBuildVersion')),
+            new \Twig_SimpleFunction('semver_build_linked', array($this, 'getLinkedBuildVersion'), array('is_safe' => array('html'))),
+        );
+    }
+
+    public function getLinkedBuildVersion($urlBuild, $urlCommit, $prefixBuild='id-', $prefixCommit='sha-',  $length=8)
+    {
+        $buildParts = $this->builder->getBuild();
+        $build = array();
+
+        foreach ($buildParts as $buildPart) {
+            // detect commit hash
+            if (strlen($buildPart) >= 40) {
+                if ($this->isSha1($buildPart)) {
+                    $build[] = '<a href="'.$urlCommit.'/'.$buildPart.'">'.substr($buildPart, 0, $length).'</a>';
+                    continue;
+                }
+
+                $build[] = '<a href="'.$urlCommit.'/'.str_replace($prefixCommit, "", $buildPart).'">'.$this->shortenSha1ContainingString($buildPart, $length).'</a>';
+                continue;
+            }
+
+            // detect build id
+            if (strpos($buildPart, $prefixBuild) !== false) {
+                $buildId = substr($buildPart,3);
+                $build[] = '<a href="'.$urlBuild.'/'.$buildId.'">'.$buildPart.'</a>';
+                continue;
+            }
+
+            $build[] = $buildPart;
+        }
+
+        return implode('.',$build);
+    }
+
+    public function getVersion($short = true)
+    {
+        if ($short){
+            return $this->getMajorVersion().'.'.$this->getMinorVersion().'.'.$this->getPatchVersion().'.'.$this->getPreReleaseVersion().'.'.$this->getBuildVersion($short);
+        }
+
+        return $this->builder->__toString();
+    }
+
+    public function getVersionGitlab($prefixBuild, $urlBuild, $prefixCommit, $urlCommit)
+    {
+        return $this->getMajorVersion().'.'.$this->getMinorVersion().'.'.$this->getPatchVersion().'.'.$this->getPreReleaseVersion().'.'.$this->getLinkedBuildVersion($prefixBuild, $urlBuild, $prefixCommit, $urlCommit);
+    }
+
+    public function getMajorVersion()
+    {
+        return $this->builder->getMajor();
+    }
+
+    public function getMinorVersion()
+    {
+        return $this->builder->getMinor();
+    }
+
+    public function getPatchVersion()
+    {
+        return $this->builder->getPatch();
+    }
+
+    public function getPreReleaseVersion()
+    {
+        return implode('.', $this->builder->getPreRelease());
+    }
+
+    public function getBuildVersion($detectAndShortenGitHash=true, $length=8)
+    {
+        if ($detectAndShortenGitHash) {
+            $build = $this->detectAndShortenGitHashFromBuild($length);
+        } else {
+            $build = $this->builder->getBuild();
+        }
+
+        return implode('.', $build);
+    }
+
+    protected function detectAndShortenGitHashFromBuild($length=8)
+    {
+        $buildParts = $this->builder->getBuild();
+        $build = array();
+
+        foreach ($buildParts as $buildPart) {
+            if (strlen($buildPart)>=40) {
+                if ($this->isSha1($buildPart)) {
+                    $build[] = substr($buildPart, 0, $length);
+                    continue;
+                }
+
+                $build[] = $this->shortenSha1ContainingString($buildPart, $length);
+                continue;
+            }
+
+            $build[] = $buildPart;
+        }
+
+        return $build;
+    }
+
+    protected function isSha1($str)
+    {
+        return (bool) preg_match('/^[0-9a-f]{40}$/i', $str);
+    }
+
+    protected function shortenSha1ContainingString($string, $length=8)
+    {
+        $parts = explode('-', $string);
+        $result = array();
+
+        foreach ($parts as $part) {
+
+            if (strlen($part) != 40) {
+                $result[] = $part;
+                continue;
+            } else {
+                if ($this->isSha1($part)) {
+                    $result[] = substr($part, 0, $length);
+                    continue;
+                }
+            }
+
+            $result[] = $part;
+        }
+
+        return implode('-', $result);
+    }
+
+    public function getName()
+    {
+        return 'version_extension';
+    }
+}


### PR DESCRIPTION
currently pre-release and build parsing are not correct.

according http://semver.org the following should work
```
php bin/console app:version:bump --prerelease=dev.0.1.0-gmma --build=asdf.asdf.asder.23434-32424
```
quote from http://semver.org
> A pre-release ... a series of **dot separated** identifiers...
>Build metadata ... a series of **dot separated** identifiers...



