### PR TITLE
Add capistrano v3 handler.

### DIFF
--- a/Handler/CapistranoHandler.php
+++ b/Handler/CapistranoHandler.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace AppBundle\Handler;
+namespace Shivas\VersioningBundle\Handler;
 
 use Herrera\Version\Validator;
 use Herrera\Version\Version;

--- a/Handler/CapistranoHandler.php
+++ b/Handler/CapistranoHandler.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace AppBundle\Handler;
+
+use Herrera\Version\Validator;
+use Herrera\Version\Version;
+use Herrera\Version\Parser;
+use Herrera\Version\Builder;
+use Shivas\VersioningBundle\Handler\HandlerInterface;
+
+class CapistranoHandler implements HandlerInterface
+{
+    const DESCRIBE_REGEX = '/^[vV]?(%s)-([0-9]*)-g([0-9a-f]{7,32})$/';
+
+    /** @var string */
+    private $path;
+
+    public function __construct($path)
+    {
+        $this->path = $path . '/../';
+    }
+
+    /**
+     * @return bool
+     */
+    public function isSupported()
+    {
+        return $this->isCapistranoEnv($this->path) && $this->canGetRevision();
+    }
+
+
+    /**
+     * If describing throws error return false, otherwise true
+     *
+     * @return bool
+     */
+    public function canGetRevision()
+    {
+        try {
+            $this->getRevision();
+        } catch (\RuntimeException $e) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @throws \RuntimeException
+     * @return Version
+     */
+    public function getVersion()
+    {
+        $semVersionRegex = substr(Validator::VERSION_REGEX, 2, -2);
+        $describeRegex = sprintf(self::DESCRIBE_REGEX, $semVersionRegex);
+
+        $version = $this->getGitDescribe();
+
+        if (!preg_match($describeRegex, $version, $matches)) {
+            throw new \RuntimeException($this->getName(). " describe returned no valid version");
+        }
+
+        $builder = Parser::toBuilder($matches[1]);
+        $this->handleMetaData($builder, $matches);
+        return $builder->getVersion();
+    }
+
+    /**
+     * @param Builder $builder
+     * @param $matches
+     */
+    protected function handleMetaData(Builder $builder, $matches)
+    {
+        if (intval($matches[7]) != 0) {
+            // we are not on TAG commit, add "dev" and git commit hash as pre release part
+            $preRelease = array_merge($builder->getPreRelease(), array('dev', $matches[8]));
+            $builder->setPreRelease($preRelease);
+        }
+    }
+
+    /**
+     * @return string
+     * @throws \RuntimeException
+     */
+    private function getRevision()
+    {
+        $result = file_get_contents($this->path . 'REVISION');
+
+        return $result;
+    }
+
+    private function isCapistranoEnv()
+    {
+        try {
+            file_get_contents($this->path . 'REVISION');
+            return true;
+        } catch (\Exception $e) {
+            return false;
+        }
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return 'Capistrano tag handler';
+    }
+}

--- a/README.md
+++ b/README.md
@@ -232,6 +232,37 @@ before "symfony:assets:install", "version:bump"
 after "version:bump", "symfony:cache:clear"
 ```
 
+
+Capistrano v3 task for version bump
+-
+
+Add following to your recipe
+``` ruby
+namespace :deploy do
+    task :add_revision_file do
+        on roles(:app) do
+            within repo_path do
+                execute(:git, :'describe', :"--tags --long",
+                :"#{fetch(:branch)}", ">#{release_path}/REVISION")
+            end
+        end
+    end
+end
+
+# We get git describe --tags just after deploy:updating
+after 'deploy:updating', 'deploy:add_revision_file'
+
+namespace :version do
+    desc "Updates version using app:version:bump symfony command"
+    task :bump do
+        invoke 'symfony:console', 'app:version:bump'
+    end
+end
+
+# After deploy bump version
+after 'deploy:finishing', 'version:bump'
+```
+
 Good luck versioning your project.
 
 Contributions for different SCM's and etc are welcome, use pull request.

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -7,11 +7,17 @@
     <parameters>
         <parameter key="shivas_versioning.manager.class">Shivas\VersioningBundle\Service\VersionsManager</parameter>
         <parameter key="shivas_versioning.handlers.git.class">Shivas\VersioningBundle\Handler\GitRepositoryHandler</parameter>
+        <parameter key="shivas_versioning.handlers.capistrano.class">Shivas\VersioningBundle\Handler\CapistranoHandler</parameter>
         <parameter key="shivas_versioning.handlers.init.class">Shivas\VersioningBundle\Handler\InitialVersionHandler</parameter>
         <parameter key="shivas_versioning.handlers.parameter.class">Shivas\VersioningBundle\Handler\ParameterHandler</parameter>
     </parameters>
 
     <services>
+        <service id="shivas_versioning.handlers.capistrano" class="%shivas_versioning.handlers.git.class%">
+            <argument>%kernel.root_dir%</argument>
+            <tag name="shivas_versioning.handler" alias="capistrano" priority="50" />
+        </service>
+
         <service id="shivas_versioning.handlers.git" class="%shivas_versioning.handlers.git.class%">
             <argument>%kernel.root_dir%</argument>
             <tag name="shivas_versioning.handler" alias="git" priority="0" />

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -13,7 +13,7 @@
     </parameters>
 
     <services>
-        <service id="shivas_versioning.handlers.capistrano" class="%shivas_versioning.handlers.git.class%">
+        <service id="shivas_versioning.handlers.capistrano" class="%shivas_versioning.handlers.capistrano.class%">
             <argument>%kernel.root_dir%</argument>
             <tag name="shivas_versioning.handler" alias="capistrano" priority="50" />
         </service>


### PR DESCRIPTION
With capistrano v3 it's not possible to use "git describe" into "current" capistrano folder after deploy. 

This new handler combined with capistrano tasks are new able to get "git describe" during the deploy process.