### PR TITLE
file_get_contents returns false with display_errors disabled

### DIFF
--- a/Handler/CapistranoHandler.php
+++ b/Handler/CapistranoHandler.php
@@ -25,9 +25,8 @@ class CapistranoHandler implements HandlerInterface
      */
     public function isSupported()
     {
-        return $this->isCapistranoEnv($this->path) && $this->canGetRevision();
+        return $this->isCapistranoEnv() && $this->canGetRevision();
     }
-
 
     /**
      * If describing throws error return false, otherwise true
@@ -37,7 +36,9 @@ class CapistranoHandler implements HandlerInterface
     public function canGetRevision()
     {
         try {
-            $this->getRevision();
+            if (false === $this->getRevision()) {
+                return false;
+            }
         } catch (\RuntimeException $e) {
             return false;
         }
@@ -89,14 +90,12 @@ class CapistranoHandler implements HandlerInterface
         return $result;
     }
 
+    /**
+     * @return bool
+     */
     private function isCapistranoEnv()
     {
-        try {
-            file_get_contents($this->path . 'REVISION');
-            return true;
-        } catch (\Exception $e) {
-            return false;
-        }
+        return file_exists($this->path . 'REVISION');
     }
 
     /**


### PR DESCRIPTION
On my production server I got the error Capistrano tag handler describe returned no valid version (#17). It turns out the Capistrano handler showed up as supported even though the REVISION file didn't exist. This was caused by the isCapistranoEnv() function not throwing an Exception but just returning false when display_errors is disabled.

Why not just use the file_exists() function to check if the REVISION exists?