### PR TITLE
Migrate to nikolaposa versioning library

### DIFF
--- a/Command/VersionBumpCommand.php
+++ b/Command/VersionBumpCommand.php
@@ -30,8 +30,8 @@ class VersionBumpCommand extends ContainerAwareCommand
             ->addOption('major', null, InputOption::VALUE_OPTIONAL, 'Bump MAJOR version by given number', 0)
             ->addOption('minor', null, InputOption::VALUE_OPTIONAL, 'Bump MINOR version by given number', 0)
             ->addOption('patch', null, InputOption::VALUE_OPTIONAL, 'Bump PATCH version by given number', 0)
-            ->addOption('prerelease', null, InputOption::VALUE_IS_ARRAY | InputOption::VALUE_OPTIONAL, 'Add PRERELEASE to version', null)
-            ->addOption('build', null, InputOption::VALUE_IS_ARRAY | InputOption::VALUE_OPTIONAL, 'Add BUILD to version', null);
+            ->addOption('prerelease', null, InputOption::VALUE_IS_ARRAY | InputOption::VALUE_OPTIONAL, 'Add PRERELEASE to version', array())
+            ->addOption('build', null, InputOption::VALUE_IS_ARRAY | InputOption::VALUE_OPTIONAL, 'Add BUILD to version', array());
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -78,7 +78,7 @@ class VersionBumpCommand extends ContainerAwareCommand
             }
 
             $preRelease = $input->getOption('prerelease');
-            if (null !== $preRelease) {
+            if (!empty($preRelease)) {
                 if (in_array(null, $preRelease)) {
                     $preRelease = array();
                 }
@@ -87,7 +87,7 @@ class VersionBumpCommand extends ContainerAwareCommand
             }
 
             $build = $input->getOption('build');
-            if (null !== $build) {
+            if (!empty($build)) {
                 if (in_array(null, $build)) {
                     $build = array();
                 }

--- a/DependencyInjection/ShivasVersioningExtension.php
+++ b/DependencyInjection/ShivasVersioningExtension.php
@@ -25,11 +25,12 @@ class ShivasVersioningExtension extends Extension
 
         $container->setParameter('shivas_versioning.version_parameter', $config['version_parameter']);
         $container->setParameter('shivas_versioning.version_file', $config['version_file']);
-        if (null !== $config['version_formatter']) {
-            $container->getDefinition('shivas_versioning.manager')->addArgument(new Reference($config['version_formatter']));
-        }
 
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');
+
+        if (null !== $config['version_formatter']) {
+            $container->getDefinition('shivas_versioning.manager')->addArgument(new Reference($config['version_formatter']));
+        }
     }
 }

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ versioning-bundle
 [![Total Downloads](https://img.shields.io/packagist/dt/shivas/versioning-bundle.svg?style=flat)](https://packagist.org/packages/shivas/versioning-bundle)
 [![Build Status](https://travis-ci.org/shivas/versioning-bundle.svg?branch=2.0.0-alpha)](https://travis-ci.org/shivas/versioning-bundle)
 
-Simple way to version your Symfony2 application.
+Simple way to version your Symfony application.
 
 What it is:
 -
@@ -14,12 +14,12 @@ What it is:
 - Basic Version providers implemented for manual and *git tag* versioning
 - Easy to extend with new providers for different SCM's or needs
 - Uses Semantic Versioning 2.0.0 recommendations using https://github.com/nikolaposa/version library
-- Uses Symfony console component to create command, can be easily integrated with Capifony to update version on every deployment
+- Uses Symfony console component to bump the version, can be easily integrated with Capifony to update on every deployment
 
 Purpose:
 -
 
-To have parameter in your Symfony2 application with current version of application for various needs:
+To have a parameter in your Symfony application with the current version of the application for various needs:
 - Display in frontend
 - Display in backend
 - Anything you can come up with
@@ -27,10 +27,10 @@ To have parameter in your Symfony2 application with current version of applicati
 Providers implemented:
 -
 
-- GitRepositoryProvider (git tag describe provider to automatically update version looking at git tags)
+- GitRepositoryProvider (git tag describe provider to automatically update the version by looking at git tags)
 - RevisionProvider (get the version from a REVISION file)
-- ParameterProvider (to manage version manually using app:version:bump command)
-- InitialVersionProvider (just returns default initial version 0.1.0)
+- ParameterProvider (to manage the version manually using the app:version:bump command)
+- InitialVersionProvider (just returns the default initial version 0.1.0)
 
 Install
 -
@@ -47,13 +47,13 @@ new Shivas\VersioningBundle\ShivasVersioningBundle()
 
 run in console:
 ```
-# This will display of available providers for version bumping
-./app/console app:version:bump -l
+# This will display all available version providers
+./bin/console app:version:bump -l
 ```
 
 ```
 # to see dry-run
-./app/console app:version:bump -d
+./bin/console app:version:bump -d
 ```
 
 Default configuration
@@ -61,15 +61,15 @@ Default configuration
 
 Default configuration of bundle looks like this:
 ```
-./app/console config:dump ShivasVersioningBundle
-Default configuration for "ShivasVersioningBundle"
+./bin/console config:dump ShivasVersioningBundle
+# Default configuration for "ShivasVersioningBundle"
 shivas_versioning:
     version_parameter:    application_version
     version_file:         parameters.yml
-
+    version_formatter:    shivas_versioning.formatters.git
 ```
 
-That means in the parameters file the `application_version` variable will be created and updated on every bump of version, you can change the name to anything you want by writing that in your config.yml file.
+That means in the parameters file the `application_version` variable will be created and updated on every version bump, you can change the name to anything you want by writing that in your config.yml file.
 You may also specify a file other than `parameters.yml` if you would like to use a custom file.  If so, make sure to import it in your config.yml file - you may want to use `ignore_errors` on the import
 to avoid issues if the file does not yet exist.
 
@@ -82,39 +82,30 @@ to avoid issues if the file does not yet exist.
         version_file:  sem_var.yml
 ```
 
-Git Provider
--
+The default version formatter is `shivas_versioning.formatters.git`. This formatter shows the version from the Git tag and adds dev.commithash as a prerelease when not on the tag commit. If you want you can disable this formatter or create your own.
 
-Git provider works only when you have atleast one TAG in your repository, and all TAGS used for versioning should follow SemVer 2.0.0 notation
-with exception, that git provider allows letter "v" or "V" to be used in your tags, e.g. v1.0.0
-
-Application version from git tag are extracted in following fashion:
-
-- v or V is stripped away
-- if commit sha matches last tag sha then tag is converted to version as is
-- if commit sha differs from last tag sha then following happens:
-  - tag is parsed as version
-  - prerelease part of SemVer is added with following data: "-dev.abcdefa"
-  - where prerelease part "dev" means that version is not tagged and is "dev" stable, and last part is commit sha
-
-This is default behavior and can be easily changed anyway you want (later on that)
+```yaml
+    # app/config/config.yml
+    shivas_versioning:
+        version_formatter: ~
+```
 
 Displaying version
 -
 
-To display version for example in page title you can add following to your config.yml:
+To display the version in the page title for example, you can add the following to your config.yml:
 ```yaml
 twig:
     globals:
         app_version: v%application_version%
 ```
 
-And then, in your Twig layout display it as global variable:
+And then, in your Twig layout display it with the global variable:
 ```html
-<title>{{ app_version }}</title>
+    <title>{{ app_version }}</title>
 ```
 
-Alternatively, if you want to display version automatically without having to bump it first, set `config.yml` to :
+Alternatively, if you want to display the version automatically without having to bump it first, set `config.yml` to :
 ```yaml
 twig:
     globals:
@@ -123,15 +114,21 @@ twig:
 
 And then, in your Twig layout:
 ```html
-<title>{{ shivas_manager.version }}</title>
+    <title>{{ shivas_manager.version }}</title>
 ```
 
-The downside is the app version will be computed every time a twig layout is loaded, even if the variable is not used in the template. However, it could be useful if you have rapid succession of new versions or if you fear to forget a version bump.
+The downside is that the version will be computed every time a twig layout is loaded, even if the variable is not used in the template. However, it could be useful if you have rapid succession of new versions or if you are afraid to forget to bump the version.
 
-Adding own providers
+Version providers
 -
 
-It's easy, write a class that implements ProviderInterface:
+Providers are used to get a version string for your application. All versions should follow the SemVer 2.0.0 notation, with the exception that letter "v" or "V" may be prefixed, e.g. v1.0.0.
+The default provider is the GitRepositoryProvider which only works when you have atleast one TAG in your repository. Be sure that all of your TAGS are valid version numbers.
+
+Adding own provider
+-
+
+It's easy, write a class that implements the ProviderInterface:
 ```php
 
 namespace Acme\AcmeBundle\Provider;
@@ -144,19 +141,19 @@ class MyCustomProvider implements ProviderInterface
 }
 ```
 
-Add provider to container using your services file (xml in my case):
+Add the provider to the container using your services file (xml in my case):
 ```xml
-        <service id="mycustom_git_provider" class="Acme\AcmeBundle\Provider\MyCustomProvider">
-            <argument>%kernel.root_dir%</argument>
-            <tag name="shivas_versioning.provider" alias="my_own_git" priority="20" />
-        </service>
+    <service id="mycustom_git_provider" class="Acme\AcmeBundle\Provider\MyCustomProvider">
+        <argument>%kernel.root_dir%</argument>
+        <tag name="shivas_versioning.provider" alias="my_own_git" priority="20" />
+    </service>
 ```
 
-Take a note on priority attribute, it should be more than 0 if you want to override default git provider as it's default value is 0.
+Take a note on the priority attribute, it should be more than 0 if you want to override the default GitRepositoryProvider as it's default value is 0.
 
 Run in console
 ```
-./app/console app:version:bump -l
+./bin/console app:version:bump -l
 ```
 
 And notice your new provider is above old one:
@@ -173,8 +170,46 @@ Registered Version providers
  ============ ========== ===================================== ===========
 ```
 
-So, next time you execute version bump, your custom git provider will take care for your version building.
+So, the next time you execute a version bump, your custom git provider will provide the version string.
 
+Version formatters
+-
+
+Version formatters are used to modify the version string to make it more readable. The default GitDescribeFormatter works in the following fashion:
+
+- if the commit sha matches the last tag sha then the tag is converted to the version as is
+- if the commit sha differs from the last tag sha then the following happens:
+  - the tag is parsed as the version
+  - the prerelease part is added with following data: "dev.abcdefa"
+  - where the prerelease part "dev" means that the version is not tagged and is "dev" stable, and the last part is the commit sha
+
+Creating your own version formatter
+-
+
+To customize the version format, write a class that implements the FormatterInterface:
+```php
+
+namespace Acme\AcmeBundle\Formatter;
+
+use Shivas\VersioningBundle\Formatter\FormatterInterface;
+
+class MyCustomFormatter implements FormatterInterface
+{
+
+}
+```
+
+Add the formatter to the container using your services file (xml in my case):
+```xml
+    <service id="mycustom_git_formatter" class="Acme\AcmeBundle\Formatter\MyCustomFormatter" />
+```
+
+Finally register your own formatter in the configuration.
+```yaml
+    # app/config/config.yml
+    shivas_versioning:
+        version_formatter: mycustom_git_formatter
+```
 
 Make Composer bump your version on install
 -
@@ -209,7 +244,6 @@ to your composer.json file to invoke it on post-install-cmd. Make sure it is abo
 },
 ```
 
-
 Capifony task for version bump
 -
 
@@ -228,7 +262,6 @@ Add following to your recipe
 before "symfony:assets:install", "version:bump"
 after "version:bump", "symfony:cache:clear"
 ```
-
 
 Capistrano v3 task for version bump
 -

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -6,7 +6,7 @@
 
     <parameters>
         <parameter key="shivas_versioning.manager.class">Shivas\VersioningBundle\Service\VersionsManager</parameter>
-        <parameter key="shivas_versioning.formatters.git.class">Shivas\VersioningBundle\Formatters\GitDescribeFormatter</parameter>
+        <parameter key="shivas_versioning.formatters.git.class">Shivas\VersioningBundle\Formatter\GitDescribeFormatter</parameter>
         <parameter key="shivas_versioning.providers.git.class">Shivas\VersioningBundle\Provider\GitRepositoryProvider</parameter>
         <parameter key="shivas_versioning.providers.revision.class">Shivas\VersioningBundle\Provider\RevisionProvider</parameter>
         <parameter key="shivas_versioning.providers.parameter.class">Shivas\VersioningBundle\Provider\ParameterProvider</parameter>


### PR DESCRIPTION
Hello,

As you know the current semantic versioning library is marked as deprecated and bugs aren't being fixed anymore. The best replacement I found is nikolaposa/version which has a very similar interface.

Because this is a pretty big refactoring I wanted to include some tests. PHPSpec seems like a good library for this but it is hard to test the handlers because they currently have two responsibilities. They need to get a version number from somewhere, a file or from git, and convert that to a version object. 

To make it easier to test the conversion to a version object I changed the way handlers work. Now there only responsibility is get a version string from somewhere, a file or git. The logic to convert the version string into a version object is now in the VersionsManager and that is a lot easier to test. Another benefit is that the handlers don't rely on the versioning library anymore.

Now with this change the flexibility to create a custom version string is lost because this logic would be put in a custom handler. I would like to rename the current handlers to providers, because they now only provide a version string. Then I could add new handlers for converting that version string into a version object. Or alternatively have a single handler for the conversion process and create customisable formatters to add the dev.hash suffix for git version strings.

There will be a BC break for the custom handlers/providers so it would a 2.0 release. But before I put more effort into this refactoring I would like to hear your opinion about this. What do you think about these changes? Suggestion or things I should be aware of?