### PR TITLE
Fix php detection when called by composer 1.3+

### DIFF
--- a/Composer/ScriptHandler.php
+++ b/Composer/ScriptHandler.php
@@ -87,6 +87,7 @@ class ScriptHandler
 
     protected static function getPhpArguments()
     {
+        $ini = null;
         $arguments = array();
 
         $phpFinder = new PhpExecutableFinder();
@@ -94,7 +95,14 @@ class ScriptHandler
             $arguments = $phpFinder->findArguments();
         }
 
-        if (false !== $ini = php_ini_loaded_file()) {
+        if ($env = strval(getenv('COMPOSER_ORIGINAL_INIS'))) {
+            $paths = explode(PATH_SEPARATOR, $env);
+            $ini = array_shift($paths);
+        } else {
+            $ini = php_ini_loaded_file();
+        }
+
+        if ($ini) {
             $arguments[] = '--php-ini=' . $ini;
         }
 


### PR DESCRIPTION
Composer 1.3+ now has the ability to turn off xdebug when running it from the commandline. It does this by running php with a custom .ini file. However the ScriptHandler needs to be updated so that it doesn't loaded the extensions twice.

Now warnings are generated when running Shivas\VersioningBundle\Composer\ScriptHandler::bumpVersion on composer 1.3+ with xdebug on: Cannot load Zend OPcache - it was already loaded

 I copied these changes from the SensioDistributionBundle who had the same issue.

For more details:
https://github.com/sensiolabs/SensioDistributionBundle/issues/299