### PR TITLE
Fix missing directory separators

### DIFF
--- a/Provider/RevisionProvider.php
+++ b/Provider/RevisionProvider.php
@@ -45,7 +45,7 @@ class RevisionProvider implements ProviderInterface
      */
     private function isCapistranoEnv()
     {
-        return file_exists($this->path . 'REVISION');
+        return file_exists($this->path . DIRECTORY_SEPARATOR . 'REVISION');
     }
 
     /**
@@ -72,7 +72,7 @@ class RevisionProvider implements ProviderInterface
      */
     private function getRevision()
     {
-        $result = file_get_contents($this->path . 'REVISION');
+        $result = file_get_contents($this->path . DIRECTORY_SEPARATOR . 'REVISION');
 
         return $result;
     }


### PR DESCRIPTION
I noticed the following warning after the RevisionProvider reported that it wasn't supported, even though I had a REVISION file in the directory:

```bash
PHP Warning:  file_get_contents(/var/www/symfony/releases/20180306130004REVISION): failed to open stream: No such file or directory in /var/www/symfony/releases/20180306130004/vendor/shivas/versioning-bundle/Provider/RevisionProvider.php on line 75
```

The GitRepositoryProvider is already aware that the path doesn't have a trailing separator: https://github.com/shivas/versioning-bundle/blob/378b268973bf4d0a01bd76ce78599b1e82d61fcf/Provider/GitRepositoryProvider.php#L50