### PR TITLE
Removed the need for a .env file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: php
 php:
-  - 7
   - 7.1
   - 7.2
   - hhvm

--- a/Command/ListProvidersCommand.php
+++ b/Command/ListProvidersCommand.php
@@ -9,6 +9,9 @@ use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+/**
+ * Class ListProvidersCommand
+ */
 class ListProvidersCommand extends Command
 {
     /**
@@ -28,6 +31,9 @@ class ListProvidersCommand extends Command
         parent::__construct();
     }
 
+    /**
+     * {@inheritdoc}
+     */
     protected function configure()
     {
         $this
@@ -37,18 +43,14 @@ class ListProvidersCommand extends Command
             );
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
-    {
-        $this->listProviders($output);
-    }
-
     /**
-     * @param OutputInterface $output
+     * List all registered providers
      */
-    protected function listProviders(OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output)
     {
         $output->writeln('Registered version providers');
         $providers = $this->manager->getProviders();
+
         $table = new Table($output);
         $table->setHeaders(array('Alias', 'Class', 'Priority', 'Supported'))
             ->setStyle('borderless');

--- a/Command/ListProvidersCommand.php
+++ b/Command/ListProvidersCommand.php
@@ -38,13 +38,11 @@ class ListProvidersCommand extends Command
     {
         $this
             ->setName('app:version:list-providers')
-            ->setDescription(
-                'List all available version providers'
-            );
+            ->setDescription('List all registered version providers');
     }
 
     /**
-     * List all registered providers
+     * List all registered version providers
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {

--- a/Command/StatusCommand.php
+++ b/Command/StatusCommand.php
@@ -5,13 +5,8 @@ namespace Shivas\VersioningBundle\Command;
 use Shivas\VersioningBundle\Formatter\FormatterInterface;
 use Shivas\VersioningBundle\Service\VersionManager;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Yaml\Parser;
-use Symfony\Component\Yaml\Yaml;
-use Version\Version;
 
 /**
  * Class StatusCommand

--- a/Command/StatusCommand.php
+++ b/Command/StatusCommand.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Shivas\VersioningBundle\Command;
+
+use Shivas\VersioningBundle\Formatter\FormatterInterface;
+use Shivas\VersioningBundle\Service\VersionManager;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Yaml\Parser;
+use Symfony\Component\Yaml\Yaml;
+use Version\Version;
+
+/**
+ * Class StatusCommand
+ */
+class StatusCommand extends Command
+{
+    /**
+     * @var VersionManager
+     */
+    private $manager;
+
+    /**
+     * Constructor
+     *
+     * @param VersionManager $manager
+     */
+    public function __construct(VersionManager $manager)
+    {
+        $this->manager = $manager;
+
+        parent::__construct();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('app:version:status')
+            ->setDescription('Show current application version');
+    }
+
+    /**
+     * Show application version status
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $output->writeln(sprintf('Provider: <comment>%s</comment>', get_class($this->manager->getActiveProvider())));
+        $formatter = $this->manager->getFormatter();
+        if ($formatter instanceof FormatterInterface) {
+            $output->writeln(sprintf('Formatter: <comment>%s</comment>', get_class($formatter)));
+        } else {
+            $output->writeln(sprintf('Formatter: <comment>%s</comment>', 'None'));
+        }
+
+        $version = $this->manager->getVersion();
+        $newVersion = $this->manager->getVersionFromProvider();
+
+        if ((string) $version == (string) $newVersion) {
+            $output->writeln(sprintf('Current version: <info>%s</info>', $version));
+        } else {
+            $output->writeln(sprintf('Current version: <error>%s</error>', $version));
+            $output->writeln(sprintf('New version: <info>%s</info>', $newVersion));
+            $output->writeln(sprintf('<comment>%s</comment>', 'Version outdated, please run the cache:clear command'));
+        }
+    }
+}

--- a/Command/StatusCommand.php
+++ b/Command/StatusCommand.php
@@ -37,11 +37,11 @@ class StatusCommand extends Command
     {
         $this
             ->setName('app:version:status')
-            ->setDescription('Show current application version');
+            ->setDescription('Show current application version status');
     }
 
     /**
-     * Show application version status
+     * Show current application version status
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {

--- a/Command/VersionBumpCommand.php
+++ b/Command/VersionBumpCommand.php
@@ -2,6 +2,7 @@
 
 namespace Shivas\VersioningBundle\Command;
 
+use Shivas\VersioningBundle\Formatter\FormatterInterface;
 use Shivas\VersioningBundle\Service\VersionManager;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -10,6 +11,9 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Version\Version;
 
+/**
+ * Class VersionBumpCommand
+ */
 class VersionBumpCommand extends Command
 {
     /**
@@ -18,24 +22,20 @@ class VersionBumpCommand extends Command
     private $manager;
 
     /**
-     * @var string
-     */
-    private $envDir;
-
-    /**
      * Constructor
      *
      * @param VersionManager $manager
-     * @param string         $envDir
      */
-    public function __construct(VersionManager $manager, $envDir)
+    public function __construct(VersionManager $manager)
     {
         $this->manager = $manager;
-        $this->envDir = $envDir;
 
         parent::__construct();
     }
 
+    /**
+     * {@inheritdoc}
+     */
     protected function configure()
     {
         $this
@@ -44,7 +44,7 @@ class VersionBumpCommand extends Command
                 'Bump application version using one of the available providers'
             )
             ->addArgument('version', InputArgument::OPTIONAL, 'Version to set, should be compatible with Semantic versioning 2.0.0', null)
-            ->addOption('dry-run', 'd', InputOption::VALUE_NONE, 'Dry run, does not update .env file')
+            ->addOption('dry-run', 'd', InputOption::VALUE_NONE, 'Dry run, does not update VERSION file')
             ->addOption('major', null, InputOption::VALUE_OPTIONAL, 'Bump MAJOR version by given number', 0)
             ->addOption('minor', null, InputOption::VALUE_OPTIONAL, 'Bump MINOR version by given number', 0)
             ->addOption('patch', null, InputOption::VALUE_OPTIONAL, 'Bump PATCH version by given number', 0)
@@ -52,75 +52,77 @@ class VersionBumpCommand extends Command
             ->addOption('build', null, InputOption::VALUE_IS_ARRAY | InputOption::VALUE_OPTIONAL, 'Add BUILD to version', array());
     }
 
+    /**
+     * Manually bump application version
+     */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         if ($input->getArgument('version') === null) {
-            $version = $this->manager->getVersion();
+            $version = $this->manager->getVersionFromProvider();
+            $output->writeln(sprintf('Provider: <comment>%s</comment>', get_class($this->manager->getActiveProvider())));
 
-            $incrementMajor = (int) $input->getOption('major');
-            if ($incrementMajor > 0) {
-                for ($i = 0; $i < $incrementMajor; $i++) {
-                    $version = $version->withMajorIncremented();
-                }
-            }
-
-            $incrementMinor = (int) $input->getOption('minor');
-            if ($incrementMinor > 0) {
-                for ($i = 0; $i < $incrementMinor; $i++) {
-                    $version = $version->withMinorIncremented();
-                }
-            }
-
-            $incrementPatch = (int) $input->getOption('patch');
-            if ($incrementPatch > 0) {
-                for ($i = 0; $i < $incrementPatch; $i++) {
-                    $version = $version->withPatchIncremented();
-                }
-            }
-
-            $preRelease = $input->getOption('prerelease');
-            if (!empty($preRelease)) {
-                if (in_array(null, $preRelease)) {
-                    $preRelease = array();
-                }
-
-                $version = $version->withPreRelease($preRelease);
-            }
-
-            $build = $input->getOption('build');
-            if (!empty($build)) {
-                if (in_array(null, $build)) {
-                    $build = array();
-                }
-
-                $version = $version->withBuild($build);
+            $formatter = $this->manager->getFormatter();
+            if ($formatter instanceof FormatterInterface) {
+                $output->writeln(sprintf('Formatter: <comment>%s</comment>', get_class($formatter)));
+            } else {
+                $output->writeln(sprintf('Formatter: <comment>%s</comment>', 'None'));
             }
         } else {
             $version = Version::fromString($input->getArgument('version'));
+            $output->writeln(sprintf('Provider: <comment>%s</comment>', 'Symfony command'));
+            $output->writeln(sprintf('Formatter: <comment>%s</comment>', 'Not available'));
         }
 
-        $output->writeln(sprintf('Provider: <comment>%s</comment>', get_class($this->manager->getActiveProvider())));
-        $output->writeln(sprintf('Formatter: <comment>%s</comment>', get_class($this->manager->getFormatter())));
-        $output->writeln(sprintf('Current version: <info>%s</info>', getenv('SHIVAS_APP_VERSION')));
-        $output->writeln(sprintf('New version: <info>%s</info>', $version->getVersionString()));
+        $incrementMajor = (int) $input->getOption('major');
+        if ($incrementMajor > 0) {
+            for ($i = 0; $i < $incrementMajor; $i++) {
+                $version = $version->withMajorIncremented();
+            }
+        }
+
+        $incrementMinor = (int) $input->getOption('minor');
+        if ($incrementMinor > 0) {
+            for ($i = 0; $i < $incrementMinor; $i++) {
+                $version = $version->withMinorIncremented();
+            }
+        }
+
+        $incrementPatch = (int) $input->getOption('patch');
+        if ($incrementPatch > 0) {
+            for ($i = 0; $i < $incrementPatch; $i++) {
+                $version = $version->withPatchIncremented();
+            }
+        }
+
+        $preRelease = $input->getOption('prerelease');
+        if (!empty($preRelease)) {
+            if (in_array(null, $preRelease)) {
+                $preRelease = array();
+            }
+
+            $version = $version->withPreRelease($preRelease);
+        }
+
+        $build = $input->getOption('build');
+        if (!empty($build)) {
+            if (in_array(null, $build)) {
+                $build = array();
+            }
+
+            $version = $version->withBuild($build);
+        }
+
+        $currentVersion = $this->manager->getVersion();
+        if ((string) $currentVersion == (string) $version) {
+            $version = $version->withPatchIncremented();
+        }
+
+        $output->writeln(sprintf('Current version: <info>%s</info>', $currentVersion));
+        $output->writeln(sprintf('New version: <info>%s</info>', $version));
         if ($input->getOption('dry-run')) {
             $output->writeln(sprintf('<question>%s</question>', 'Dry run, skipping version bump'));
         } else {
-            $this->setEnvironmentValue('SHIVAS_APP_VERSION', $version->getVersionString());
+            $this->manager->writeVersion($version);
         }
-    }
-
-    /**
-     * @param string $envKey
-     * @param string $envValue
-     */
-    protected function setEnvironmentValue($envKey, $envValue)
-    {
-        $str = file_get_contents($this->envDir . '/.env');
-
-        $oldValue = getenv('SHIVAS_APP_VERSION');
-        $str = str_replace("{$envKey}={$oldValue}", "{$envKey}={$envValue}", $str);
-
-        file_put_contents($this->envDir . '/.env', $str);
     }
 }

--- a/Command/VersionBumpCommand.php
+++ b/Command/VersionBumpCommand.php
@@ -40,9 +40,7 @@ class VersionBumpCommand extends Command
     {
         $this
             ->setName('app:version:bump')
-            ->setDescription(
-                'Bump application version using one of the available providers'
-            )
+            ->setDescription('Manually bump the application version')
             ->addArgument('version', InputArgument::OPTIONAL, 'Version to set, should be compatible with Semantic versioning 2.0.0', null)
             ->addOption('dry-run', 'd', InputOption::VALUE_NONE, 'Dry run, does not update VERSION file')
             ->addOption('major', null, InputOption::VALUE_OPTIONAL, 'Bump MAJOR version by given number', 0)
@@ -53,7 +51,7 @@ class VersionBumpCommand extends Command
     }
 
     /**
-     * Manually bump application version
+     * Manually bump the application version
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {

--- a/Provider/InitialVersionProvider.php
+++ b/Provider/InitialVersionProvider.php
@@ -5,7 +5,7 @@ namespace Shivas\VersioningBundle\Provider;
 /**
  * Class InitialVersionProvider
  *
- * Fallback provider to get initial version, later Parameters or Git providers should be able to take over
+ * Fallback provider to get initial version
  */
 class InitialVersionProvider implements ProviderInterface
 {

--- a/Provider/VersionProvider.php
+++ b/Provider/VersionProvider.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Shivas\VersioningBundle\Provider;
+
+use RuntimeException;
+
+/**
+ * Class VersionProvider
+ */
+class VersionProvider implements ProviderInterface
+{
+    /**
+     * @var string
+     */
+    private $path;
+
+    /**
+     * Constructor
+     *
+     * @param $path
+     */
+    public function __construct($path)
+    {
+        $this->path = $path;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isSupported()
+    {
+        return $this->hasVersionFile() && $this->canGetVersion();
+    }
+
+    /**
+     * @return string
+     */
+    public function getVersion()
+    {
+        $result = file_get_contents($this->path . DIRECTORY_SEPARATOR . 'VERSION');
+
+        return $result;
+    }
+
+    /**
+     * @return bool
+     */
+    private function hasVersionFile()
+    {
+        return file_exists($this->path . DIRECTORY_SEPARATOR . 'VERSION');
+    }
+
+    /**
+     * @return boolean
+     * @throws RuntimeException
+     */
+    private function canGetVersion()
+    {
+        try {
+            if (false === $this->getVersion()) {
+                return false;
+            }
+        } catch (RuntimeException $e) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -93,18 +93,18 @@ Add the provider to the container using your services file:
 ```yaml
 App\Provider\MyCustomProvider:
     tags:
-        - { name: shivas_versioning.provider, alias: my_provider, priority: 25 }
+        - { name: shivas_versioning.provider, alias: my_provider, priority: 0 }
 ```
 
 ```xml
 <service id="App\Provider\MyCustomProvider">
-    <tag name="shivas_versioning.provider" alias="my_provider" priority="25" />
+    <tag name="shivas_versioning.provider" alias="my_provider" priority="0" />
 </service>
 ```
 
-Please take a look at the priority attribute, it should be more than 0 as it's the value of the default provider.
+Please take a look at the priority attribute, it should be between 0 and 99 to keep the providers in the right order.
 
-Ensure your provider is loaded correctly:
+Ensure your provider is loaded correctly and supported:
 ```
 bin/console app:version:list-providers
 
@@ -112,8 +112,8 @@ Registered version providers
  ============= ========================================================= ========== ===========
   Alias         Class                                                     Priority   Supported
  ============= ========================================================= ========== ===========
-  my_provider   App\Provider\MyCustomProvider                             25         Yes
-  version       Shivas\VersioningBundle\Provider\VersionProvider          0          Yes
+  version       Shivas\VersioningBundle\Provider\VersionProvider          100        No
+  my_provider   App\Provider\MyCustomProvider                             0          Yes
   git           Shivas\VersioningBundle\Provider\GitRepositoryProvider    -25        Yes
   revision      Shivas\VersioningBundle\Provider\RevisionProvider         -50        No
   init          Shivas\VersioningBundle\Provider\InitialVersionProvider   -75        Yes

--- a/README.md
+++ b/README.md
@@ -10,12 +10,11 @@ Simple way to version your Symfony Flex application.
 What it is:
 -
 
-- Adds an additional environment variable and keeps it updated with your current application version
+- Automatically keep track of your application version using Git tags or a Capistrano REVISION file
 - Adds a global Twig variable for easy access
-- Basic Version providers implemented for manual and *git tag* versioning
-- Easy to extend with new providers for different SCM's or needs
+- Easy to extend with new version providers and formatters for different SCM's or needs
 - Uses Semantic Versioning 2.0.0 recommendations using https://github.com/nikolaposa/version library
-- Uses Symfony console command to bump the version on every deployment
+- Support for manual version management
 
 Purpose:
 -
@@ -28,6 +27,7 @@ To have an environment variable in your Symfony application with the current ver
 Providers implemented:
 -
 
+- VersionProvider (read the version from a VERSION file)
 - GitRepositoryProvider (git tag describe provider to automatically update the version by looking at git tags)
 - RevisionProvider (read the version from a REVISION file)
 - InitialVersionProvider (just returns the default initial version 0.1.0)
@@ -35,51 +35,43 @@ Providers implemented:
 Installation
 -
 
-Symfony Flex automates the installation, just require the bundle in your application!
+Symfony Flex automates the installation process, just require the bundle in your application!
 ```
 composer require shivas/versioning-bundle
 ```
 
-The version is automatically updated with Composer and available in your application.
+The version is automatically available in your application.
 ```
-# PHP
-getenv('SHIVAS_APP_VERSION')
-
-# Twig
+# Twig template
 {{ shivas_app_version }}
-```
 
-Alternatively, if you want to display the version automatically without having to bump it first, set the versioning manager as a Twig global.
-However this is not recommended.
-```yaml
-twig:
-    globals:
-        shivas_manager: '@Shivas\VersioningBundle\Service\VersionManager'
-```
-
-And then, in your Twig layout:
-```
-# Twig
-{{ shivas_manager.version }}
+# Or get the version from the service
+public function indexAction(VersionManager $manager)
+{
+    $version = $manager->getVersion();
+}
 ```
 
 Console commands
 -
 
-There are two available console commands. The app:version:bump command is automatically called by Composer on every install and update.
+There are three available console commands. You only need to run the app:version:bump command when manually managing your version number.
 ```
-# This will display all available version providers
+# Display the application version status
+bin/console app:version:status
+
+# Display all available version providers
 bin/console app:version:list-providers
 
-# Display a dry run of a version bump
-bin/console app:version:bump -d
+# Manually bump the application version
+bin/console app:version:bump
 ```
 
 Version providers
 -
 
 Providers are used to get a version string for your application. All versions should follow the SemVer 2.0.0 notation, with the exception that letter "v" or "V" may be prefixed, e.g. v1.0.0.
-The default provider is the GitRepositoryProvider which only works when you have atleast one TAG in your repository. Be sure that all of your TAGS are valid version numbers.
+The recommended version provider is the GitRepositoryProvider which only works when you have atleast one TAG in your repository. Be sure that all of your TAGS are valid version numbers.
 
 Adding own provider
 -
@@ -87,7 +79,7 @@ Adding own provider
 It's easy, write a class that implements the ProviderInterface:
 ```php
 
-namespace Acme\AcmeBundle\Provider;
+namespace App\Provider;
 
 use Shivas\VersioningBundle\Provider\ProviderInterface;
 
@@ -98,13 +90,19 @@ class MyCustomProvider implements ProviderInterface
 ```
 
 Add the provider to the container using your services file:
+```yaml
+App\Provider\MyCustomProvider:
+    tags:
+        - { name: shivas_versioning.provider, alias: my_provider, priority: 25 }
+```
+
 ```xml
 <service id="App\Provider\MyCustomProvider">
     <tag name="shivas_versioning.provider" alias="my_provider" priority="25" />
 </service>
 ```
 
-Please take a look at the priority attribute, it should be more than 0 if you want to override the default GitRepositoryProvider as it's default value is 0.
+Please take a look at the priority attribute, it should be more than 0 as it's the value of the default provider.
 
 Ensure your provider is loaded correctly:
 ```
@@ -114,14 +112,13 @@ Registered version providers
  ============= ========================================================= ========== ===========
   Alias         Class                                                     Priority   Supported
  ============= ========================================================= ========== ===========
-  my_provider   App\Provider\CustomProvider                               25         Yes
-  git           Shivas\VersioningBundle\Provider\GitRepositoryProvider    0          Yes
-  revision      Shivas\VersioningBundle\Provider\RevisionProvider         -25        No
-  init          Shivas\VersioningBundle\Provider\InitialVersionProvider   -50        Yes
+  my_provider   App\Provider\MyCustomProvider                             25         Yes
+  version       Shivas\VersioningBundle\Provider\VersionProvider          0          Yes
+  git           Shivas\VersioningBundle\Provider\GitRepositoryProvider    -25        Yes
+  revision      Shivas\VersioningBundle\Provider\RevisionProvider         -50        No
+  init          Shivas\VersioningBundle\Provider\InitialVersionProvider   -75        Yes
  ============= ========================================================= ========== ===========
 ```
-
-The next time you bump the version, your custom git provider will provide the version string.
 
 Version formatters
 -

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -1,61 +1,63 @@
 <?xml version="1.0" ?>
 
 <container xmlns="http://symfony.com/schema/dic/services"
-           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
-        <service id="Shivas\VersioningBundle\Formatter\FormatterInterface"
-                 alias="Shivas\VersioningBundle\Formatter\GitDescribeFormatter"/>
-        <service id="Shivas\VersioningBundle\Writer\WriterInterface"
-                 alias="Shivas\VersioningBundle\Writer\VersionWriter"/>
-
-        <service id="Shivas\VersioningBundle\Service\VersionManager">
-            <argument type="service" id="Symfony\Component\Cache\Adapter\AdapterInterface"/>
+        <service id="Shivas\VersioningBundle\Service\VersionManager" public="true">
+            <argument type="service" id="shivas_versioning.cache.version"/>
             <argument type="service" id="Shivas\VersioningBundle\Writer\WriterInterface"/>
             <argument type="service" id="Shivas\VersioningBundle\Formatter\FormatterInterface"/>
         </service>
 
-        <service id="Shivas\VersioningBundle\Formatter\GitDescribeFormatter"/>
-        <service id="Shivas\VersioningBundle\Writer\VersionWriter">
+        <service id="Shivas\VersioningBundle\Formatter\FormatterInterface" alias="shivas_versioning.formatter.git" public="false"/>
+        <service id="Shivas\VersioningBundle\Writer\WriterInterface" alias="shivas_versioning.writer.version" public="false"/>
+
+        <service id="shivas_versioning.formatter.git" class="Shivas\VersioningBundle\Formatter\GitDescribeFormatter" public="false"/>
+        <service id="shivas_versioning.writer.version" class="Shivas\VersioningBundle\Writer\VersionWriter" public="false">
             <argument>%kernel.project_dir%</argument>
         </service>
 
-        <service id="Shivas\VersioningBundle\Provider\VersionProvider">
+        <service id="shivas_versioning.provider.version" class="Shivas\VersioningBundle\Provider\VersionProvider" public="false">
             <argument>%kernel.project_dir%</argument>
             <tag name="shivas_versioning.provider" alias="version" priority="0"/>
         </service>
 
-        <service id="Shivas\VersioningBundle\Provider\GitRepositoryProvider">
+        <service id="shivas_versioning.provider.git" class="Shivas\VersioningBundle\Provider\GitRepositoryProvider" public="false">
             <argument>%kernel.project_dir%</argument>
             <tag name="shivas_versioning.provider" alias="git" priority="-25"/>
         </service>
 
-        <service id="Shivas\VersioningBundle\Provider\RevisionProvider">
+        <service id="shivas_versioning.provider.revision" class="Shivas\VersioningBundle\Provider\RevisionProvider" public="false">
             <argument>%kernel.project_dir%</argument>
             <tag name="shivas_versioning.provider" alias="revision" priority="-50"/>
         </service>
 
-        <service id="Shivas\VersioningBundle\Provider\InitialVersionProvider">
+        <service id="shivas_versioning.provider.init" class="Shivas\VersioningBundle\Provider\InitialVersionProvider" public="false">
             <tag name="shivas_versioning.provider" alias="init" priority="-75"/>
         </service>
 
-        <service id="Shivas\VersioningBundle\Command\StatusCommand">
+        <service id="shivas_versioning.cache.version" parent="cache.system" public="false">
+            <tag name="cache.pool" />
+        </service>
+
+        <service id="shivas_versioning.command.status" class="Shivas\VersioningBundle\Command\StatusCommand" public="false">
             <argument type="service" id="Shivas\VersioningBundle\Service\VersionManager"/>
             <tag name="console.command"/>
         </service>
 
-        <service id="Shivas\VersioningBundle\Command\ListProvidersCommand">
+        <service id="shivas_versioning.command.list_providers" class="Shivas\VersioningBundle\Command\ListProvidersCommand" public="false">
             <argument type="service" id="Shivas\VersioningBundle\Service\VersionManager"/>
             <tag name="console.command"/>
         </service>
 
-        <service id="Shivas\VersioningBundle\Command\VersionBumpCommand">
+        <service id="shivas_versioning.command.version_bump" class="Shivas\VersioningBundle\Command\VersionBumpCommand" public="false">
             <argument type="service" id="Shivas\VersioningBundle\Service\VersionManager"/>
             <tag name="console.command"/>
         </service>
 
-        <service id="Shivas\VersioningBundle\Twig\VersionExtension">
+        <service id="shivas_versioning.twig.version" class="Shivas\VersioningBundle\Twig\VersionExtension" public="false">
             <argument type="service" id="Shivas\VersioningBundle\Service\VersionManager"/>
             <tag name="twig.extension"/>
         </service>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -5,26 +5,44 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
+        <service id="Shivas\VersioningBundle\Formatter\FormatterInterface"
+                 alias="Shivas\VersioningBundle\Formatter\GitDescribeFormatter"/>
+        <service id="Shivas\VersioningBundle\Writer\WriterInterface"
+                 alias="Shivas\VersioningBundle\Writer\VersionWriter"/>
+
         <service id="Shivas\VersioningBundle\Service\VersionManager">
+            <argument type="service" id="Symfony\Component\Cache\Adapter\AdapterInterface"/>
+            <argument type="service" id="Shivas\VersioningBundle\Writer\WriterInterface"/>
             <argument type="service" id="Shivas\VersioningBundle\Formatter\FormatterInterface"/>
         </service>
 
         <service id="Shivas\VersioningBundle\Formatter\GitDescribeFormatter"/>
-        <service id="Shivas\VersioningBundle\Formatter\FormatterInterface"
-                 alias="Shivas\VersioningBundle\Formatter\GitDescribeFormatter"/>
+        <service id="Shivas\VersioningBundle\Writer\VersionWriter">
+            <argument>%kernel.project_dir%</argument>
+        </service>
+
+        <service id="Shivas\VersioningBundle\Provider\VersionProvider">
+            <argument>%kernel.project_dir%</argument>
+            <tag name="shivas_versioning.provider" alias="version" priority="0"/>
+        </service>
 
         <service id="Shivas\VersioningBundle\Provider\GitRepositoryProvider">
             <argument>%kernel.project_dir%</argument>
-            <tag name="shivas_versioning.provider" alias="git" priority="0"/>
+            <tag name="shivas_versioning.provider" alias="git" priority="-25"/>
         </service>
 
         <service id="Shivas\VersioningBundle\Provider\RevisionProvider">
             <argument>%kernel.project_dir%</argument>
-            <tag name="shivas_versioning.provider" alias="revision" priority="-25"/>
+            <tag name="shivas_versioning.provider" alias="revision" priority="-50"/>
         </service>
 
         <service id="Shivas\VersioningBundle\Provider\InitialVersionProvider">
-            <tag name="shivas_versioning.provider" alias="init" priority="-50"/>
+            <tag name="shivas_versioning.provider" alias="init" priority="-75"/>
+        </service>
+
+        <service id="Shivas\VersioningBundle\Command\StatusCommand">
+            <argument type="service" id="Shivas\VersioningBundle\Service\VersionManager"/>
+            <tag name="console.command"/>
         </service>
 
         <service id="Shivas\VersioningBundle\Command\ListProvidersCommand">
@@ -34,11 +52,11 @@
 
         <service id="Shivas\VersioningBundle\Command\VersionBumpCommand">
             <argument type="service" id="Shivas\VersioningBundle\Service\VersionManager"/>
-            <argument>%kernel.project_dir%</argument>
             <tag name="console.command"/>
         </service>
 
         <service id="Shivas\VersioningBundle\Twig\VersionExtension">
+            <argument type="service" id="Shivas\VersioningBundle\Service\VersionManager"/>
             <tag name="twig.extension"/>
         </service>
     </services>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -5,36 +5,38 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
+        <defaults public="false"/>
+
         <service id="Shivas\VersioningBundle\Service\VersionManager" public="true">
             <argument type="service" id="shivas_versioning.cache.version"/>
             <argument type="service" id="Shivas\VersioningBundle\Writer\WriterInterface"/>
             <argument type="service" id="Shivas\VersioningBundle\Formatter\FormatterInterface"/>
         </service>
 
-        <service id="Shivas\VersioningBundle\Formatter\FormatterInterface" alias="shivas_versioning.formatter.git" public="false"/>
-        <service id="Shivas\VersioningBundle\Writer\WriterInterface" alias="shivas_versioning.writer.version" public="false"/>
+        <service id="Shivas\VersioningBundle\Formatter\FormatterInterface" alias="shivas_versioning.formatter.git"/>
+        <service id="Shivas\VersioningBundle\Writer\WriterInterface" alias="shivas_versioning.writer.version"/>
 
-        <service id="shivas_versioning.formatter.git" class="Shivas\VersioningBundle\Formatter\GitDescribeFormatter" public="false"/>
-        <service id="shivas_versioning.writer.version" class="Shivas\VersioningBundle\Writer\VersionWriter" public="false">
+        <service id="shivas_versioning.formatter.git" class="Shivas\VersioningBundle\Formatter\GitDescribeFormatter"/>
+        <service id="shivas_versioning.writer.version" class="Shivas\VersioningBundle\Writer\VersionWriter">
             <argument>%kernel.project_dir%</argument>
         </service>
 
-        <service id="shivas_versioning.provider.version" class="Shivas\VersioningBundle\Provider\VersionProvider" public="false">
+        <service id="shivas_versioning.provider.version" class="Shivas\VersioningBundle\Provider\VersionProvider">
             <argument>%kernel.project_dir%</argument>
-            <tag name="shivas_versioning.provider" alias="version" priority="0"/>
+            <tag name="shivas_versioning.provider" alias="version" priority="100"/>
         </service>
 
-        <service id="shivas_versioning.provider.git" class="Shivas\VersioningBundle\Provider\GitRepositoryProvider" public="false">
+        <service id="shivas_versioning.provider.git" class="Shivas\VersioningBundle\Provider\GitRepositoryProvider">
             <argument>%kernel.project_dir%</argument>
             <tag name="shivas_versioning.provider" alias="git" priority="-25"/>
         </service>
 
-        <service id="shivas_versioning.provider.revision" class="Shivas\VersioningBundle\Provider\RevisionProvider" public="false">
+        <service id="shivas_versioning.provider.revision" class="Shivas\VersioningBundle\Provider\RevisionProvider">
             <argument>%kernel.project_dir%</argument>
             <tag name="shivas_versioning.provider" alias="revision" priority="-50"/>
         </service>
 
-        <service id="shivas_versioning.provider.init" class="Shivas\VersioningBundle\Provider\InitialVersionProvider" public="false">
+        <service id="shivas_versioning.provider.init" class="Shivas\VersioningBundle\Provider\InitialVersionProvider">
             <tag name="shivas_versioning.provider" alias="init" priority="-75"/>
         </service>
 
@@ -42,22 +44,22 @@
             <tag name="cache.pool" />
         </service>
 
-        <service id="shivas_versioning.command.status" class="Shivas\VersioningBundle\Command\StatusCommand" public="false">
+        <service id="shivas_versioning.command.status" class="Shivas\VersioningBundle\Command\StatusCommand">
             <argument type="service" id="Shivas\VersioningBundle\Service\VersionManager"/>
             <tag name="console.command"/>
         </service>
 
-        <service id="shivas_versioning.command.list_providers" class="Shivas\VersioningBundle\Command\ListProvidersCommand" public="false">
+        <service id="shivas_versioning.command.list_providers" class="Shivas\VersioningBundle\Command\ListProvidersCommand">
             <argument type="service" id="Shivas\VersioningBundle\Service\VersionManager"/>
             <tag name="console.command"/>
         </service>
 
-        <service id="shivas_versioning.command.version_bump" class="Shivas\VersioningBundle\Command\VersionBumpCommand" public="false">
+        <service id="shivas_versioning.command.version_bump" class="Shivas\VersioningBundle\Command\VersionBumpCommand">
             <argument type="service" id="Shivas\VersioningBundle\Service\VersionManager"/>
             <tag name="console.command"/>
         </service>
 
-        <service id="shivas_versioning.twig.version" class="Shivas\VersioningBundle\Twig\VersionExtension" public="false">
+        <service id="shivas_versioning.twig.version" class="Shivas\VersioningBundle\Twig\VersionExtension">
             <argument type="service" id="Shivas\VersioningBundle\Service\VersionManager"/>
             <tag name="twig.extension"/>
         </service>

--- a/Service/VersionManager.php
+++ b/Service/VersionManager.php
@@ -125,42 +125,34 @@ class VersionManager
      * Write a new version number to the cache and storage
      *
      * @param   Version $version
-     * @throws  RuntimeException
+     * @throws  InvalidArgumentException
      */
     public function writeVersion(Version $version)
     {
-        try {
-            $cacheItem = $this->cache->getItem('version');
-            $cacheItem->set($version);
+        $cacheItem = $this->cache->getItem('version');
+        $cacheItem->set($version);
 
-            $this->cache->save($cacheItem);
-            $this->writer->write($version);
-        } catch (InvalidArgumentException $e) {
-            throw new RuntimeException('Could not write version cache item: ' . $e->getMessage());
-        }
+        $this->cache->save($cacheItem);
+        $this->writer->write($version);
     }
 
     /**
      * Get the current application version
      *
      * @return Version
-     * @throws RuntimeException
+     * @throws InvalidArgumentException
      */
     public function getVersion()
     {
-        try {
-            $cacheItem = $this->cache->getItem('version');
-            if ($cacheItem->isHit()) {
-                return $cacheItem->get();
-            } else {
-                $version = $this->getVersionFromProvider();
-                $cacheItem->set($version);
-                $this->cache->save($cacheItem);
+        $cacheItem = $this->cache->getItem('version');
+        if ($cacheItem->isHit()) {
+            return $cacheItem->get();
+        } else {
+            $version = $this->getVersionFromProvider();
+            $cacheItem->set($version);
+            $this->cache->save($cacheItem);
 
-                return $version;
-            }
-        } catch (InvalidArgumentException $e) {
-            throw new RuntimeException('Could not get version cache item: ' . $e->getMessage());
+            return $version;
         }
     }
 

--- a/Service/VersionManager.php
+++ b/Service/VersionManager.php
@@ -5,6 +5,8 @@ namespace Shivas\VersioningBundle\Service;
 use RuntimeException;
 use Shivas\VersioningBundle\Formatter\FormatterInterface;
 use Shivas\VersioningBundle\Provider\ProviderInterface;
+use Shivas\VersioningBundle\Writer\WriterInterface;
+use Symfony\Component\Cache\Adapter\AdapterInterface;
 use Version\Exception\InvalidVersionStringException;
 use Version\Version;
 
@@ -14,33 +16,47 @@ use Version\Version;
 class VersionManager
 {
     /**
+     * @var AdapterInterface
+     */
+    private $cache;
+
+    /**
+     * @var WriterInterface
+     */
+    private $writer;
+
+    /**
      * @var FormatterInterface
      */
     private $formatter;
 
     /**
-     * @var array
-     */
-    private $providers;
-
-    /**
-     * @var array
+     * @var ProviderInterface
      */
     private $activeProvider;
 
     /**
+     * @var array
+     */
+    private $providers = [];
+
+    /**
      * Constructor
      *
+     * @param AdapterInterface   $cache
+     * @param WriterInterface    $writer
      * @param FormatterInterface $formatter
      */
-    public function __construct(FormatterInterface $formatter = null)
+    public function __construct(AdapterInterface $cache, WriterInterface $writer, FormatterInterface $formatter = null)
     {
+        $this->cache = $cache;
+        $this->writer = $writer;
         $this->formatter = $formatter;
-        $this->providers = array();
-        $this->activeProvider = null;
     }
 
     /**
+     * Register a provider
+     *
      * @param ProviderInterface $provider
      * @param string            $alias
      * @param integer           $priority
@@ -50,10 +66,9 @@ class VersionManager
         $this->providers[$alias] = array(
             'provider' => $provider,
             'priority' => $priority,
-            'alias' => $alias
+            'alias' => $alias,
         );
 
-        // sort providers by priority
         uasort(
             $this->providers,
             function ($a, $b) {
@@ -67,46 +82,6 @@ class VersionManager
     }
 
     /**
-     * @return Version
-     */
-    public function getVersion()
-    {
-        $provider = $this->getSupportedProvider();
-
-        try {
-            $versionString = $provider->getVersion();
-            if (substr(strtolower($versionString), 0, 1) == 'v') {
-                $versionString = substr($versionString, 1);
-            }
-
-            $version = Version::fromString($versionString);
-            if (null !== $this->formatter) {
-                $version = $this->formatter->format($version);
-            }
-
-            return $version;
-        } catch (InvalidVersionStringException $e) {
-            throw new RuntimeException(get_class($provider) . ' returned an invalid version');
-        }
-    }
-
-    /**
-     * @return FormatterInterface|null
-     */
-    public function getFormatter()
-    {
-        return $this->formatter;
-    }
-
-    /**
-     * @return ProviderInterface
-     */
-    public function getActiveProvider()
-    {
-        return $this->activeProvider['provider'];
-    }
-
-    /**
      * Returns array of registered providers
      *
      * @return array
@@ -117,11 +92,17 @@ class VersionManager
     }
 
     /**
+     * Returns the active provider
+     *
      * @return ProviderInterface
      * @throws RuntimeException
      */
-    public function getSupportedProvider()
+    public function getActiveProvider()
     {
+        if ($this->activeProvider instanceof ProviderInterface) {
+            return $this->activeProvider;
+        }
+
         if (empty($this->providers)) {
             throw new RuntimeException('No versioning provider found');
         }
@@ -130,12 +111,82 @@ class VersionManager
             $provider = $entry['provider'];
             /** @var $provider ProviderInterface */
             if ($provider->isSupported()) {
-                $this->activeProvider = $entry;
+                $this->activeProvider = $provider;
 
                 return $provider;
             }
         }
 
         throw new RuntimeException('No supported versioning providers found');
+    }
+
+    /**
+     * Write a new version number to the cache and storage
+     *
+     * @param Version $version
+     */
+    public function writeVersion(Version $version)
+    {
+        $cacheItem = $this->cache->getItem('version');
+        $cacheItem->set($version);
+
+        $this->cache->save($cacheItem);
+        $this->writer->write($version);
+    }
+
+    /**
+     * Get the current application version
+     *
+     * @return Version
+     */
+    public function getVersion()
+    {
+        $cacheItem = $this->cache->getItem('version');
+        if ($cacheItem->isHit()) {
+            return $cacheItem->get();
+        } else {
+            $version = $this->getVersionFromProvider();
+            $cacheItem->set($version);
+            $this->cache->save($cacheItem);
+
+            return $version;
+        }
+    }
+
+    /**
+     * Get the version from the active provider
+     *
+     * @return Version
+     * @throws RuntimeException
+     */
+    public function getVersionFromProvider()
+    {
+        $provider = $this->getActiveProvider();
+
+        try {
+            $versionString = $provider->getVersion();
+            if (substr(strtolower($versionString), 0, 1) == 'v') {
+                $versionString = substr($versionString, 1);
+            }
+
+            $version = Version::fromString($versionString);
+            if ($this->formatter instanceof FormatterInterface) {
+                $version = $this->formatter->format($version);
+            }
+
+            return $version;
+        } catch (InvalidVersionStringException $e) {
+            throw new RuntimeException(get_class($provider) . ' returned an invalid version');
+        }
+    }
+
+    /**
+     * Get the formatter
+     *
+     * @return FormatterInterface|null
+     */
+    public function getFormatter()
+    {
+        return $this->formatter;
     }
 }

--- a/Twig/VersionExtension.php
+++ b/Twig/VersionExtension.php
@@ -2,6 +2,7 @@
 
 namespace Shivas\VersioningBundle\Twig;
 
+use Shivas\VersioningBundle\Service\VersionManager;
 use Twig_Extension;
 use Twig_Extension_GlobalsInterface;
 
@@ -11,12 +12,22 @@ use Twig_Extension_GlobalsInterface;
 class VersionExtension extends Twig_Extension implements Twig_Extension_GlobalsInterface
 {
     /**
+     * @var VersionManager
+     */
+    protected $manager;
+
+    public function __construct(VersionManager $manager)
+    {
+        $this->manager = $manager;
+    }
+
+    /**
      * @return array
      */
     public function getGlobals()
     {
         return [
-            'shivas_app_version' => getenv('SHIVAS_APP_VERSION'),
+            'shivas_app_version' => (string) $this->manager->getVersion(),
         ];
     }
 }

--- a/Writer/VersionWriter.php
+++ b/Writer/VersionWriter.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Shivas\VersioningBundle\Writer;
+
+use Version\Version;
+
+/**
+ * Class VersionWriter
+ */
+class VersionWriter implements WriterInterface
+{
+    /**
+     * @var string
+     */
+    private $path;
+
+    /**
+     * Constructor
+     *
+     * @param $path
+     */
+    public function __construct($path)
+    {
+        $this->path = $path;
+    }
+
+    /**
+     * @param Version $version
+     */
+    public function write(Version $version)
+    {
+        file_put_contents($this->path . DIRECTORY_SEPARATOR . 'VERSION', $version);
+    }
+}

--- a/Writer/WriterInterface.php
+++ b/Writer/WriterInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Shivas\VersioningBundle\Writer;
+
+use Version\Version;
+
+/**
+ * Interface WriterInterface
+ */
+interface WriterInterface
+{
+    /**
+     * @param  Version $version
+     * @return Version
+     */
+    public function write(Version $version);
+}


### PR DESCRIPTION
The .env file and the Flex recipe aren't needed anymore after these changes, but let me try to explain why I've done them this way.

The parameters.yml / .env file had two purposes:
1) Provide easy and fast access to the version number; we don't want to call the providers every time we need the version number
2) Provide a persistent storage for the version number when not using Git or Revision files (hence the parameterProvider we had)

The version bump command also has two purposes:
1) Update the parameter.yml file with the current version fetched from other providers
2) Manually bump the version number with the major/minor/patch options

Both 1) points are easily solved using the filesystem cache that Symfony provides. If the cache is empty the version number is fetched from the providers and if it's not empty we have the fast access we want. We also don't need the bump command anymore because the cache is cleared after every deployment so the version gets updated automatically.

However using a cache for points 2) doens't make sense, it's not persistent. I think the most elegant way to solve this is by using a VERSION file. I thought about just using the REVISION file instead, but since Capistrano uses that file I think it's better to keep it seperated. Also, I wanted this VersionProvider at the highest priority for manually bumping the version, while the RevisionProvider is below the GitDescribe provider.

Long story short... when using Git tags or the REVISION file to provide the version, everything should just work out of the box. The bump command is only there for manually bumping the version, it creates a VERSION file which can be committed and deployed alongside the code. I also created a status command to check the version in the cache.

@shivas If you approve these changes, I'll remove the Flex recipe before you merge things. We don't want to run the bump command anymore and the recipe automates that part.