### PR TITLE
Skip file

### DIFF
--- a/Provider/GitRepositoryProvider.php
+++ b/Provider/GitRepositoryProvider.php
@@ -44,7 +44,9 @@ class GitRepositoryProvider implements ProviderInterface
         if ($this->canGitDescribe()) {
             $version = $this->getGitDescribe();
             // if "write to file" (and thus VersionProvider Priority is < -25)
-                fwrite(fopen($this->path . DIRECTORY_SEPARATOR . 'VERSION', 'w+b'),$version);
+                $handle = fopen($this->path . DIRECTORY_SEPARATOR . 'GIT_VERSION', 'w+b');
+                fwrite($handle,$version);
+                fclose($handle);
             // end config flag check
             return $version;
         } else {
@@ -104,7 +106,9 @@ class GitRepositoryProvider implements ProviderInterface
      */
     private function getFileVersion()
     {
-        $result = fgets(fopen($this->path . DIRECTORY_SEPARATOR . 'GIT_VERSION', 'rb'));
+        $handle = fopen($this->path . DIRECTORY_SEPARATOR . 'GIT_VERSION', 'rb');
+        $result = fgets($handle);
+        fclose($handle);
 
         return trim($result);
     }

--- a/Provider/GitRepositoryProvider.php
+++ b/Provider/GitRepositoryProvider.php
@@ -38,7 +38,10 @@ class GitRepositoryProvider implements ProviderInterface
      */
     public function getVersion()
     {
-        return $this->getGitDescribe();
+        $vString = $this->getGitDescribe();
+        // if "write to file" (and thus VersionProvider Priority is < -25)
+        fwrite(fopen($this->path . DIRECTORY_SEPARATOR . 'VERSION', 'w+b'),$this->getGitDescribe());
+        return $vString;
     }
 
     /**

--- a/Provider/GitRepositoryProvider.php
+++ b/Provider/GitRepositoryProvider.php
@@ -38,10 +38,10 @@ class GitRepositoryProvider implements ProviderInterface
      */
     public function getVersion()
     {
-        $vString = $this->getGitDescribe();
+        $version = $this->getGitDescribe();
         // if "write to file" (and thus VersionProvider Priority is < -25)
-        fwrite(fopen($this->path . DIRECTORY_SEPARATOR . 'VERSION', 'w+b'),$this->getGitDescribe());
-        return $vString;
+        fwrite(fopen($this->path . DIRECTORY_SEPARATOR . 'VERSION', 'w+b'),$version);
+        return $version;
     }
 
     /**

--- a/Provider/GitRepositoryProvider.php
+++ b/Provider/GitRepositoryProvider.php
@@ -43,7 +43,7 @@ class GitRepositoryProvider implements ProviderInterface
     {
         if ($this->canGitDescribe()) {
             $version = $this->getGitDescribe();
-            // if "write to file" (and thus VersionProvider Priority is < -25)
+            // if config "write to file" == true
                 $handle = fopen($this->path . DIRECTORY_SEPARATOR . 'GIT_VERSION', 'w+b');
                 fwrite($handle,$version);
                 fclose($handle);

--- a/Provider/VersionProvider.php
+++ b/Provider/VersionProvider.php
@@ -37,7 +37,9 @@ class VersionProvider implements ProviderInterface
      */
     public function getVersion()
     {
-        $result = fgets(fopen($this->path . DIRECTORY_SEPARATOR . 'VERSION', 'rb'));
+        $handle = fopen($this->path . DIRECTORY_SEPARATOR . 'VERSION', 'rb');
+        $result = fgets($handle);
+        fclose($handle);
 
         return trim($result);
     }

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -23,7 +23,7 @@
 
         <service id="shivas_versioning.provider.version" class="Shivas\VersioningBundle\Provider\VersionProvider">
             <argument>%kernel.project_dir%</argument>
-            <tag name="shivas_versioning.provider" alias="version" priority="100"/>
+            <tag name="shivas_versioning.provider" alias="version" priority="-30"/>
         </service>
 
         <service id="shivas_versioning.provider.git" class="Shivas\VersioningBundle\Provider\GitRepositoryProvider">


### PR DESCRIPTION
How might this be setup in a less hackish way?

The idea is that I want to use the GitRepositoryProvider, and have it generate a/the VERSION file.

git must have priority over [the file] version, so that it runs every time (on the development environment) but once the site is deployed [to AWS EB] git no longer exists and the VERSION file is read.

(I also merged the other recent edits - they seemed a good change)

I thought of adding a configuration option "write to file" that would create the file, then signal a "last priority" provider to then check for that file.