### PR TITLE
Update nikolaposa/version to version 4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /bin/
 /composer.lock
 /vendor/
+/docker-compose.yml

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@
 /bin/
 /composer.lock
 /vendor/
-/docker-compose.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ cache:
         - $HOME/.composer/cache/files
 
 addons:
-  apt:
-    packages:
-    - jq
+    apt:
+        packages:
+            - jq
 
 env:
     global:
@@ -18,13 +18,14 @@ matrix:
     fast_finish: true
     include:
           # Minimum supported dependencies with the latest and oldest PHP version
-        - php: 7.4
+        - php: 7.2
           env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
-        - php: 7.1
+        - php: 7.3
+          env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
+        - php: 7.4
           env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
 
           # Test the latest stable release
-        - php: 7.1
         - php: 7.2
         - php: 7.3
         - php: 7.4
@@ -69,8 +70,8 @@ script:
     - ./vendor/bin/phpunit ${PHPUNIT_FLAGS}
 
 after_script:
-  - |
-    if [ "$COVERAGE" = true ] && [ -e coverage.clover ]; then
-      wget https://scrutinizer-ci.com/ocular.phar
-      php ocular.phar code-coverage:upload --format=php-clover coverage.clover
-    fi
+    - |
+      if [ "$COVERAGE" = true ] && [ -e coverage.clover ]; then
+        wget https://scrutinizer-ci.com/ocular.phar
+        php ocular.phar code-coverage:upload --format=php-clover coverage.clover
+      fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,11 +18,9 @@ matrix:
     fast_finish: true
     include:
           # Minimum supported dependencies with the latest and oldest PHP version
-        - php: 7.2
-          env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
-        - php: 7.3
-          env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
         - php: 7.4
+          env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
+        - php: 7.2
           env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
 
           # Test the latest stable release

--- a/Command/VersionBumpCommand.php
+++ b/Command/VersionBumpCommand.php
@@ -72,34 +72,31 @@ class VersionBumpCommand extends Command
             $output->writeln(sprintf('Formatter: <comment>%s</comment>', 'Not available'));
         }
 
-        // Used for BC compatibility with nikolaposa/version 2.2
-        $isNikolaposaVersion2 = method_exists($version, 'withMajorIncremented');
-
         $incrementMajor = (int) $input->getOption('major');
         if ($incrementMajor > 0) {
             for ($i = 0; $i < $incrementMajor; $i++) {
-                $version = $isNikolaposaVersion2 ? $version->withMajorIncremented() : $version->incrementMajor();
+                $version = $version->incrementMajor();
             }
         }
 
         $incrementMinor = (int) $input->getOption('minor');
         if ($incrementMinor > 0) {
             for ($i = 0; $i < $incrementMinor; $i++) {
-                $version = $isNikolaposaVersion2 ? $version->withMinorIncremented() : $version->incrementMinor();
+                $version = $version->incrementMinor();
             }
         }
 
         $incrementPatch = (int) $input->getOption('patch');
         if ($incrementPatch > 0) {
             for ($i = 0; $i < $incrementPatch; $i++) {
-                $version = $isNikolaposaVersion2 ? $version->withPatchIncremented() : $version->incrementPatch();
+                $version = $version->incrementPatch();
             }
         }
 
         $preRelease = $input->getOption('prerelease');
         if (!empty($preRelease)) {
             if (in_array(null, $preRelease, true)) {
-                $preRelease = $isNikolaposaVersion2 ? array() : null;
+                $preRelease = null;
             } else {
                 $preRelease = implode('.', $preRelease);
             }
@@ -110,7 +107,7 @@ class VersionBumpCommand extends Command
         $build = $input->getOption('build');
         if (!empty($build)) {
             if (in_array(null, $build, true)) {
-                $build = $isNikolaposaVersion2 ? array() : null;
+                $build = null;
             } else {
                 $build = implode('.', $build);
             }
@@ -120,7 +117,7 @@ class VersionBumpCommand extends Command
 
         $currentVersion = $this->manager->getVersion();
         if ((string) $currentVersion === (string) $version) {
-            $version = $isNikolaposaVersion2 ? $version->withPatchIncremented() : $version->incrementPatch();
+            $version = $version->incrementPatch();
         }
 
         $output->writeln(sprintf('Current version: <info>%s</info>', $currentVersion));

--- a/Command/VersionBumpCommand.php
+++ b/Command/VersionBumpCommand.php
@@ -62,10 +62,11 @@ class VersionBumpCommand extends Command
 
             $formatter = $this->manager->getFormatter();
             if ($formatter instanceof FormatterInterface) {
-                $output->writeln(sprintf('Formatter: <comment>%s</comment>', get_class($formatter)));
+                $textOutput = get_class($formatter);
             } else {
-                $output->writeln(sprintf('Formatter: <comment>%s</comment>', 'None'));
+                $textOutput = 'None';
             }
+            $output->writeln(sprintf('Formatter: <comment>%s</comment>', $textOutput));
         } else {
             $version = Version::fromString($input->getArgument('version'));
             $output->writeln(sprintf('Provider: <comment>%s</comment>', 'Symfony command'));

--- a/Command/VersionBumpCommand.php
+++ b/Command/VersionBumpCommand.php
@@ -62,11 +62,10 @@ class VersionBumpCommand extends Command
 
             $formatter = $this->manager->getFormatter();
             if ($formatter instanceof FormatterInterface) {
-                $textOutput = get_class($formatter);
+                $output->writeln(sprintf('Formatter: <comment>%s</comment>', get_class($formatter)));
             } else {
-                $textOutput = 'None';
+                $output->writeln(sprintf('Formatter: <comment>%s</comment>', 'None'));
             }
-            $output->writeln(sprintf('Formatter: <comment>%s</comment>', $textOutput));
         } else {
             $version = Version::fromString($input->getArgument('version'));
             $output->writeln(sprintf('Provider: <comment>%s</comment>', 'Symfony command'));

--- a/Formatter/GitDescribeFormatter.php
+++ b/Formatter/GitDescribeFormatter.php
@@ -39,16 +39,15 @@ class GitDescribeFormatter implements FormatterInterface
                     $withPreRelease = sprintf('%s.dev.%s', trim($matches[1], '-'), $matches[3]);
                 }
 
-                $version = $version->withPreRelease($withPreRelease);
             } else {
                 if ('' === $matches[1]) {
                     $withPreRelease = null;
                 } else {
                     $withPreRelease = trim($matches[1], '-');
                 }
-
-                $version = $version->withPreRelease($withPreRelease);
             }
+
+            $version = $version->withPreRelease($withPreRelease);
         }
 
         return $version;

--- a/Formatter/GitDescribeFormatter.php
+++ b/Formatter/GitDescribeFormatter.php
@@ -2,6 +2,7 @@
 
 namespace Shivas\VersioningBundle\Formatter;
 
+use Version\Extension\PreRelease;
 use Version\Version;
 
 /**
@@ -15,44 +16,29 @@ class GitDescribeFormatter implements FormatterInterface
      * @param  Version $version
      * @return Version
      */
-    public function format(Version $version)
+    public function format(Version $version): Version
     {
-        if (preg_match('/^(\d+)-g([a-fA-F0-9]{7,40})(-dirty)?$/', $version->getPreRelease(), $matches)) {
-            if ((int) $matches[1] != 0) {
-                // we are not on TAG commit, add "dev" and git commit hash as pre release part
-                $version = $version->withPreRelease('dev.' . $matches[2]);
-            } else {
-                $version = $this->clearPreRelease($version);
-            }
+        $preRelease = $version->getPreRelease();
+        if (!$preRelease instanceof PreRelease) {
+            return $version;
         }
 
-        if (preg_match('/^(.*)-(\d+)-g([a-fA-F0-9]{7,40})(-dirty)?$/', $version->getPreRelease(), $matches)) {
+        if (preg_match('/^(\d+)-g([a-fA-F0-9]{7,40})(-dirty)?$/', $preRelease->toString(), $matches)) {
+            $withPreRelease = (int) $matches[1] != 0 ? sprintf('dev.%s',  $matches[2]) : null;
+            $version = $version->withPreRelease($withPreRelease);
+        }
+
+        if (preg_match('/^(.*)-(\d+)-g([a-fA-F0-9]{7,40})(-dirty)?$/', $preRelease->toString(), $matches)) {
             if ((int) $matches[2] != 0) {
-                // we are not on TAG commit, add "dev" and git commit hash as pre release part
-                if (empty($matches[1])) {
-                    $version = $version->withPreRelease('dev.' . $matches[3]);
-                } else {
-                    $version = $version->withPreRelease(trim($matches[1], '-') . '.dev.' . $matches[3]);
-                }
+                // if we are not on TAG commit, add "dev" and git commit hash as pre release part
+                $withPreRelease = empty($matches[1]) ? sprintf('dev.%s',  $matches[3]) : sprintf('%s.dev.%s', trim($matches[1], '-'),  $matches[3]);
+                $version = $version->withPreRelease($withPreRelease);
             } else {
-                if (empty($matches[1])) {
-                    $version = $this->clearPreRelease($version);
-                } else {
-                    $version = $version->withPreRelease(trim($matches[1], '-'));
-                }
+                $withPreRelease = empty($matches[1]) ? null : trim($matches[1], '-');
+                $version = $version->withPreRelease($withPreRelease);
             }
         }
 
         return $version;
-    }
-
-    private function clearPreRelease(Version $version): Version
-    {
-        if (class_exists(\Version\Metadata\PreRelease::class)) {
-            // we cannot use null with nikolaposa/version 2.2
-            return $version->withPreRelease(\Version\Metadata\PreRelease::createEmpty());
-        } else {
-            return $version->withPreRelease(null);
-        }
     }
 }

--- a/Formatter/GitDescribeFormatter.php
+++ b/Formatter/GitDescribeFormatter.php
@@ -2,7 +2,6 @@
 
 namespace Shivas\VersioningBundle\Formatter;
 
-use Version\Extension\PreRelease;
 use Version\Version;
 
 /**
@@ -19,22 +18,35 @@ class GitDescribeFormatter implements FormatterInterface
     public function format(Version $version): Version
     {
         $preRelease = $version->getPreRelease();
-        if (!$preRelease instanceof PreRelease) {
+        if (null === $preRelease) {
             return $version;
         }
 
         if (preg_match('/^(\d+)-g([a-fA-F0-9]{7,40})(-dirty)?$/', $preRelease->toString(), $matches)) {
-            $withPreRelease = (int) $matches[1] != 0 ? sprintf('dev.%s',  $matches[2]) : null;
-            $version = $version->withPreRelease($withPreRelease);
-        }
+            if ('0' !== $matches[1]) {
+                $withPreRelease = sprintf('dev.%s', $matches[2]);
+            } else {
+                $withPreRelease = null;
+            }
 
-        if (preg_match('/^(.*)-(\d+)-g([a-fA-F0-9]{7,40})(-dirty)?$/', $preRelease->toString(), $matches)) {
-            if ((int) $matches[2] != 0) {
+            $version = $version->withPreRelease($withPreRelease);
+        } elseif (preg_match('/^(.*)-(\d+)-g([a-fA-F0-9]{7,40})(-dirty)?$/', $preRelease->toString(), $matches)) {
+            if ('0' !== $matches[2]) {
                 // if we are not on TAG commit, add "dev" and git commit hash as pre release part
-                $withPreRelease = empty($matches[1]) ? sprintf('dev.%s',  $matches[3]) : sprintf('%s.dev.%s', trim($matches[1], '-'),  $matches[3]);
+                if (empty($matches[1])) {
+                    $withPreRelease = sprintf('dev.%s', $matches[3]);
+                } else {
+                    $withPreRelease = sprintf('%s.dev.%s', trim($matches[1], '-'), $matches[3]);
+                }
+
                 $version = $version->withPreRelease($withPreRelease);
             } else {
-                $withPreRelease = empty($matches[1]) ? null : trim($matches[1], '-');
+                if ('' === $matches[1]) {
+                    $withPreRelease = null;
+                } else {
+                    $withPreRelease = trim($matches[1], '-');
+                }
+
                 $version = $version->withPreRelease($withPreRelease);
             }
         }

--- a/Service/VersionManager.php
+++ b/Service/VersionManager.php
@@ -8,7 +8,7 @@ use Shivas\VersioningBundle\Formatter\FormatterInterface;
 use Shivas\VersioningBundle\Provider\ProviderInterface;
 use Shivas\VersioningBundle\Writer\WriterInterface;
 use Symfony\Component\Cache\Adapter\AdapterInterface;
-use Version\Exception\InvalidVersionStringException;
+use Version\Exception\InvalidVersionString;
 use Version\Version;
 
 /**
@@ -178,7 +178,7 @@ class VersionManager
             }
 
             return $version;
-        } catch (InvalidVersionStringException $e) {
+        } catch (InvalidVersionString $e) {
             throw new RuntimeException(get_class($provider) . ' returned an invalid version');
         }
     }

--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
         "wiki": "https://github.com/shivas/versioning-bundle/wiki"
     },
     "require": {
-        "php": "^7.1",
-        "nikolaposa/version": "^2.2 || ^3",
+        "php": "^7.2",
+        "nikolaposa/version": "^4",
         "symfony/console": "^3.4 || ^4 || ^5",
         "symfony/framework-bundle": "^3.4 || ^4 || ^5",
         "symfony/process": "^3.4 || ^4 || ^5"


### PR DESCRIPTION
@dontub 

I have a question.
Why do you keep the old version of nikolaposa/version (v2 and v3) ?
dependencies of nikolaposa/version are:
 - v4 => beberlei/assert and php ^7.2 (so you can upgrade your package to php 7.2, too)
 - v3 => php ^7.2 (so you can upgrade your package to php 7.2, too)
 - v2 => php ^5.5 (this time, it's shivas/versionning that locks to php 7.1)

So, to put it in a nutshell,
If you want to keep shivas/versionning compatible with php 7.1, version 2 of nikolaposa/version is mandatory.
Without it, only version 4 of nikolaposa/version is required.