### PR TITLE
Support PHP 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "wiki": "https://github.com/shivas/versioning-bundle/wiki"
     },
     "require": {
-        "php": "^7.1",
+        "php": "^7.1 || ^8.0",
         "nikolaposa/version": "^2.2 || ^3",
         "symfony/console": "^3.4 || ^4 || ^5",
         "symfony/framework-bundle": "^3.4 || ^4 || ^5",


### PR DESCRIPTION
This MR adds support for PHP 8. The unit tests seem to pass. As this is my first time contributing, please let me know if you want things differently :)

```
$ php -v
PHP 8.0.0 (cli) (built: Nov 27 2020 17:41:45) ( NTS )
Copyright (c) The PHP Group
Zend Engine v4.0.0-dev, Copyright (c) Zend Technologies

$ ./vendor/bin/phpunit
PHPUnit 8.5.14 by Sebastian Bergmann and contributors.

Testing Default
.............................                                     29 / 29 (100%)

Time: 142 ms, Memory: 6.00 MB

OK (29 tests, 31 assertions)
```