### PR TITLE
Solve sf 7 deprecation

### DIFF
--- a/src/DependencyInjection/ShivasVersioningExtension.php
+++ b/src/DependencyInjection/ShivasVersioningExtension.php
@@ -4,7 +4,7 @@ namespace Shivas\VersioningBundle\DependencyInjection;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader;
 
 final class ShivasVersioningExtension extends Extension


### PR DESCRIPTION
Hi,

I tried this lib with SF7 and got a deprecation, 
```
The "Symfony\Component\HttpKernel\DependencyInjection\Extension" class is considered internal since Symfony 7.1, to be deprecated in 8.1; use Symfony\Component\DependencyInjection\Extension\Extension instead. It may change without further notice. You should not use it from "Shivas\VersioningBundle\DependencyInjection\ShivasVersioningExtension".
```

This PR solve it, and since the file exist in 5.4 versions, it will still be compatible with every SF 7 versions.

Closes https://github.com/shivas/versioning-bundle/issues/96