### PR TITLE
Use explicit nullable type in GitRepositoryProviderTest.

### DIFF
--- a/tests/Provider/GitRepositoryProviderTest.php
+++ b/tests/Provider/GitRepositoryProviderTest.php
@@ -159,7 +159,7 @@ EOPHP
         eval(<<<EOPHP
 namespace Shivas\VersioningBundle\Provider;
 
-function exec(string \$command, array &\$execOutput = null, int &\$execExitCode = null): string
+function exec(string \$command, ?array &\$execOutput = null, ?int &\$execExitCode = null): string
 {
     if ('git describe --tags --long 2>&1' === \$command) {
         \$execOutput = $self::\$gitDescribeOutput;


### PR DESCRIPTION
Fix deprecations in tests.

```
  1x: Shivas\VersioningBundle\Provider\exec(): Implicitly marking parameter $execOutput as nullable is deprecated, the explicit nullable type must be used instead
    1x in GitRepositoryProviderTest::setUpBeforeClass from Shivas\VersioningBundle\Tests\Provider

  1x: Shivas\VersioningBundle\Provider\exec(): Implicitly marking parameter $execExitCode as nullable is deprecated, the explicit nullable type must be used instead
    1x in GitRepositoryProviderTest::setUpBeforeClass from Shivas\VersioningBundle\Tests\Provider
```